### PR TITLE
find first free port 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,15 @@ find an unused port in your localhost
 	findPort([8000, 8011], function(ports) {
 		console.log(ports)
 	})
+
+	// find first free port in a range
+	findPort(8000, 8003, true, function(port) {
+    	console.log(port)
+    })
+
+    // find first free port in array
+    findPort([8000, 8011], true, function(port) {
+        console.log(port)
+    })
+
 ```

--- a/lib/findPort.js
+++ b/lib/findPort.js
@@ -36,8 +36,17 @@ function buildJobFromArguments(args) {
 
 
 module.exports = function(start, end, shouldFindFirst, callback) {
+
+    var arrayShuffle = function(o) {
+        for (var j, x, i = o.length; i; j = Math.floor(Math.random() * i), x = o[--i], o[i] = o[j], o[j] = x) {
+            // see http://stackoverflow.com/questions/6274339/how-can-i-shuffle-an-array-in-javascript
+        }
+    };
+
     var job = buildJobFromArguments(arguments);
-    var asyncFunc = job.shouldFindFirst ? 'detect' : 'filter';
+    var asyncFunc = job.shouldFindFirst ? (arrayShuffle(job.ports), 'detectSeries') : 'filter';
+    // we shuffle array, to randomize our chances to find free port
+    // as port usage grows, this is still better than search from the beginning
     async[asyncFunc](job.ports, probe, job.callback);
 }
 

--- a/lib/findPort.js
+++ b/lib/findPort.js
@@ -1,75 +1,82 @@
-var net = require('net')
-var async = require('async')
-var util = require('util')
+var net = require('net'),
+    async = require('async'),
+    util = require('util');
 
-module.exports = function(start, endOrCallback, callback) {
+function buildJobFromArguments(args) {
 
-	if (arguments.length < 2)
-		throw new Error('missing callback')
+    var assertInt = function(value, argName) {
+        return value === parseInt(value, 10) ? value : (function() { throw new Error(argName + ' should be integer')})();
+    };
 
-	if (arguments.length === 2 && typeof endOrCallback !== 'function')
-		throw new Error('missing callback')
+    var range = function(start, end) {
+        assertInt(start, 'start');
+        assertInt(end, 'end');
+        if (end <= start) return [];
+        var result = [];
+        for (var i = start; i <= end; i++)
+            result.push(i)
+        return result;
+    };
 
-	if (arguments.length >= 3 && typeof callback !== 'function')
-		throw new Error('missing callback')
+    var callbackAtIndex = function(idx) {
+        return typeof args[idx] === 'function' ? args[idx] : (function () {throw new Error('missing callback');})();
+    };
 
-	if (typeof endOrCallback === 'function') {
-		callback = endOrCallback
-		endOrCallback = 0
-	}
+    return {
+        callback: callbackAtIndex(args.length-1),
+        // callback is always last, fail if not
 
-	var ports
+        ports: util.isArray(args[0]) ? args[0] : range(args[0], args[1]),
+        // first arg is array, or first pair are ints
 
-	if (util.isArray(start)) {
-		ports = start
-	} else {
+        shouldFindFirst: args.length == 4 ? args[2] === true : args.length == 3 ? (args[1] === true) : false
+        // === true value, might be second or third argument
+    };
+}
 
-		ports = []
 
-		for (var i = start; i <= endOrCallback; i++)
-			ports.push(i)
-	}
-
-	async.filter(ports, probe, callback)
+module.exports = function(start, end, shouldFindFirst, callback) {
+    var job = buildJobFromArguments(arguments);
+    var asyncFunc = job.shouldFindFirst ? 'detect' : 'filter';
+    async[asyncFunc](job.ports, probe, job.callback);
 }
 
 function probe(port, callback) {
+	var server = net.createServer().listen(port);
 
-	var server = net.createServer().listen(port)
-
-	var calledOnce = false
+	var calledOnce = false;
 
 	var timeoutRef = setTimeout(function () {
-		calledOnce = true
-		callback(false)
-	}, 2000)
+		calledOnce = true;
+		callback(false);
+	}, 2000);
 
-	timeoutRef.unref()
+	timeoutRef.unref();
 
-	var connected = false
+	var connected = false;
 
 	server.on('listening', function() {
-		clearTimeout(timeoutRef)
+		clearTimeout(timeoutRef);
 
 		if (server)
-			server.close()
+			server.close();
 
 		if (!calledOnce) {
-			calledOnce = true
-			callback(true)
+			calledOnce = true;
+			callback(true);
 		}
-	})
+	});
 
 	server.on('error', function(err) {
-		clearTimeout(timeoutRef)
+		clearTimeout(timeoutRef);
 
-		var result = true
+		var result = true;
 		if (err.code === 'EADDRINUSE')
-			result = false
+			result = false;
 
 		if (!calledOnce) {
-			calledOnce = true
-			callback(result)
+			calledOnce = true;
+			callback(result);
 		}
 	})
 }

--- a/test/findPort.test.js
+++ b/test/findPort.test.js
@@ -32,6 +32,25 @@ describe('findPort', function () {
 		})
 	})
 
+    it('throws an error if arguments are insane (1)', function () {
+        assert.throws(function () {
+            findPort(9000, 'string', function() { })
+        })
+    })
+
+
+    it('throws an error if arguments are insane (2)', function () {
+
+        assert.throws(function () {
+            findPort('string', 4, function() { })
+        })
+
+    })
+
+
+
+
+
 	it('finds unused ports in a range', function (done) {
 
 		findPort(9000, 9003, function(ports) {
@@ -40,6 +59,16 @@ describe('findPort', function () {
 		})
 	})
 
+
+    it('find single unused port in a range', function (done) {
+
+        findPort(9000, 9003, true, function(port) {
+            assert.equal(port, 9001)
+            done()
+        })
+    })
+
+
 	it('finds unused ports in an array', function (done) {
 
 		findPort([9000, 9003], function(ports) {
@@ -47,4 +76,26 @@ describe('findPort', function () {
 			done()
 		})
 	})
+
+    it('finds unused ports in an array, when told so using false', function(done) {
+
+        findPort([9000, 9003], false, function(ports) {
+            assert.deepEqual(ports, [9003])
+            done()
+        })
+    })
+
+    it('finds single unused port in an array', function (done) {
+
+        findPort([9000, 9003], true, function(port) {
+            assert.equal(port, 9003)
+            done()
+        })
+
+    })
+
+
+
+
+
 })

--- a/test/findPort.test.js
+++ b/test/findPort.test.js
@@ -63,7 +63,7 @@ describe('findPort', function () {
     it('find single unused port in a range', function (done) {
 
         findPort(9000, 9003, true, function(port) {
-            assert.equal(port, 9001)
+            assert(port == 9001 || port == 9002 || port == 9003)
             done()
         })
     })
@@ -89,6 +89,15 @@ describe('findPort', function () {
 
         findPort([9000, 9003], true, function(port) {
             assert.equal(port, 9003)
+            done()
+        })
+
+    })
+
+    it('finds single unused port in a big range ', function (done) {
+
+        findPort(9000, 19000, true, function(port) {
+            assert(port >= 9000 && port <= 19000);
             done()
         })
 


### PR DESCRIPTION
I need a library, that could find a single port in a port range for me. Decided to add an arguments for yours. I don't want node to check all ports at once (doing that in parallel wont help, most of the time will be used in a context switches), the first one available will do. 

I've kept the API 100% compatible, by introducing one more optional argument. 

Additionally:
- buildJobFromArguments better handles optional function arguments 
