### PR TITLE
add EACCES to the busy port condition

### DIFF
--- a/lib/findPort.js
+++ b/lib/findPort.js
@@ -58,7 +58,7 @@ module.exports = function(host, start, endOrCallback, callback) {
 			clearTimeout(timeoutRef)
 
 			var result = true
-			if (err.code === 'EADDRINUSE') {
+			if (err.code === 'EADDRINUSE' || err.code === 'EACCES') {
 				result = false
 			}
 


### PR DESCRIPTION
When the port is on the "Listening" state, error code is EACCES.